### PR TITLE
Fix type of repo name and rev name.

### DIFF
--- a/klaus/views.py
+++ b/klaus/views.py
@@ -69,7 +69,8 @@ class BaseRepoView(KlausTemplateView):
         context = super(BaseRepoView, self).get_context_data(**ctx)
 
         repo = RepoManager.get_repo(str(self.kwargs['repo']))
-        rev = str(self.kwargs.get('rev'))
+        rev = self.kwargs.get('rev')
+        if rev: rev = str(rev)
         path = self.kwargs.get('path')
         if isinstance(path, unicode):
             path = path.encode("utf-8")

--- a/klaus/views.py
+++ b/klaus/views.py
@@ -68,8 +68,8 @@ class BaseRepoView(KlausTemplateView):
     def get_context_data(self, **ctx):
         context = super(BaseRepoView, self).get_context_data(**ctx)
 
-        repo = RepoManager.get_repo(self.kwargs['repo'])
-        rev = self.kwargs.get('rev')
+        repo = RepoManager.get_repo(str(self.kwargs['repo']))
+        rev = str(self.kwargs.get('rev'))
         path = self.kwargs.get('path')
         if isinstance(path, unicode):
             path = path.encode("utf-8")


### PR DESCRIPTION
```
Traceback:
...
File "/home/sgs/pyenv/envs/D/local/lib/python2.7/site-packages/klaus/views.py" in get_context_data
  162.         context = super(HistoryView, self).get_context_data(**ctx)
File "/home/sgs/pyenv/envs/D/local/lib/python2.7/site-packages/klaus/views.py" in get_context_data
  113.         context = super(TreeViewMixin, self).get_context_data(**ctx)
File "/home/sgs/pyenv/envs/D/local/lib/python2.7/site-packages/klaus/views.py" in get_context_data
  82.             commit = repo.get_commit(rev)
File "/home/sgs/pyenv/envs/D/local/lib/python2.7/site-packages/klaus/repo.py" in get_commit
  75.                 obj = self[key]
File "/home/sgs/pyenv/envs/D/local/lib/python2.7/site-packages/dulwich/repo.py" in __getitem__
  449.                     type(name).__name__)

Exception Type: TypeError at /klaus/00001/tree/master/user/sgs/
Exception Value: 'name' must be bytestring, not unicode
```
