### PR TITLE
unicode support added in rev

### DIFF
--- a/klaus/views.py
+++ b/klaus/views.py
@@ -73,8 +73,10 @@ class BaseRepoView(KlausTemplateView):
         path = self.kwargs.get('path')
         if isinstance(path, unicode):
             path = path.encode("utf-8")
-
-        if rev is None:
+	if isinstance(rev, unicode):
+            rev = rev.encode("utf-8")
+        
+	if rev is None:
             rev = repo.get_default_branch()
             if rev is None:
                 raise RepoException("Empty repository")


### PR DESCRIPTION
Traceback:
File "/home/melon/PycharmProjects/venv/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  132.                     response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/home/melon/PycharmProjects/venv/lib/python2.7/site-packages/django/views/generic/base.py" in view
  71.             return self.dispatch(request, *args, **kwargs)
File "/home/melon/PycharmProjects/venv/lib/python2.7/site-packages/django/views/generic/base.py" in dispatch
  89.         return handler(request, *args, **kwargs)
File "/home/melon/PycharmProjects/venv/lib/python2.7/site-packages/django/views/generic/base.py" in get
  158.         context = self.get_context_data(**kwargs)
File "/home/melon/PycharmProjects/venv/lib/python2.7/site-packages/klaus/views.py" in get_context_data
  162.         context = super(HistoryView, self).get_context_data(**ctx)
File "/home/melon/PycharmProjects/venv/lib/python2.7/site-packages/klaus/views.py" in get_context_data
  113.         context = super(TreeViewMixin, self).get_context_data(**ctx)
File "/home/melon/PycharmProjects/venv/lib/python2.7/site-packages/klaus/views.py" in get_context_data
  82.             commit = repo.get_commit(rev)
File "/home/melon/PycharmProjects/venv/lib/python2.7/site-packages/klaus/repo.py" in get_commit
  75.                 obj = self[key]
File "/home/melon/PycharmProjects/venv/lib/python2.7/site-packages/dulwich/repo.py" in __getitem__
  467.                     type(name).__name__)

Exception Type: TypeError at /klaus/sn/tree/master/account/
Exception Value: 'name' must be bytestring, not unicode

Fixed the problem of unicode.